### PR TITLE
Content Analytics: document Paid Media channel components

### DIFF
--- a/help/content-analytics/report/components.md
+++ b/help/content-analytics/report/components.md
@@ -161,11 +161,6 @@ In the tables below, ![AI generated](/help/assets/icons/AI.svg) indicates an AI/
 {style="table-layout:fixed"}
 -->
 
-<!-- PAID MEDIA (generated) — The "Paid Media" section below (and the `Paid Media` value added to the
-     Channel dimension above) are generated and kept in sync by the `paid-media-doc-sync` skill
-     (repo: github.com/dbunker_adobe/xdm-paid-media) from the AEP Paid Media source connectors, the
-     XDM paid-media schema, and the ares_aca_config provisioning templates. Do not hand-edit the Paid
-     Media rows — edits are overwritten on the next sync. To change them, run the skill and open a new PR. -->
 ## Paid Media
 
 These components are added to a data view when the **Paid Media** channel is enabled through an [Adobe Experience Platform Paid Media source connector](https://experienceleague.adobe.com/en/docs/experience-platform/sources/home) (for example, Meta Ads or Google Ads). They let you report on paid media entities and spend alongside your web and mobile content.

--- a/help/content-analytics/report/components.md
+++ b/help/content-analytics/report/components.md
@@ -41,6 +41,7 @@ Content Analytics adds the following categories of components (dimensions, (calc
 * [Asset metadata](#asset-metadata)
 * [Asset attributes](#asset-attributes)
 * [Asset events](#asset-events)
+* [Paid Media](#paid-media)
 * [Calculated metrics](#calculated-metrics)
 
 In the tables below, ![AI generated](/help/assets/icons/AI.svg) indicates an AI/ML generated attribute / value pair. 
@@ -50,7 +51,7 @@ In the tables below, ![AI generated](/help/assets/icons/AI.svg) indicates an AI/
 | Title | Description | Type |
 |---|---|---|
 | ID Source | For Content Analytics, the value is `ContentAnalytics`. | Dimension |
-| Channel | Channel for the experience. Value is either `Web` or `Mobile`. | Dimension |
+| Channel | Channel for the experience. Value is either `Web`, `Mobile`, or `Paid Media`. | Dimension |
 | Content Experience ID | Unique id for the experience. <br>For **web**: URL of the web page. <br/>For **granular web**: a hash calcuated client side based on the content payload (texts, images, ctas) with prefix `web-`. <br/>For **mobile**: a hash calcuated client side based on the content payload (texts, images, ctas) with prefix `mobile-`.| Dimension |
 | Content Experience Source | For **web**: the URL of the web page.<br/>For **mobile**: the screen name, passed in through the Experience Platform Mobile SDK.  | Dimension |
 | Experience Channel (deprecated) | Channel for the experience. Value is either `Web` or `Mobile`. | Dimension |
@@ -160,6 +161,33 @@ In the tables below, ![AI generated](/help/assets/icons/AI.svg) indicates an AI/
 {style="table-layout:fixed"}
 -->
 
+<!-- PAID MEDIA (generated) — The "Paid Media" section below (and the `Paid Media` value added to the
+     Channel dimension above) are generated and kept in sync by the `paid-media-doc-sync` skill
+     (repo: github.com/dbunker_adobe/xdm-paid-media) from the AEP Paid Media source connectors, the
+     XDM paid-media schema, and the ares_aca_config provisioning templates. Do not hand-edit the Paid
+     Media rows — edits are overwritten on the next sync. To change them, run the skill and open a new PR. -->
+## Paid Media
+
+These components are added to a data view when the **Paid Media** channel is enabled through an [Adobe Experience Platform Paid Media source connector](https://experienceleague.adobe.com/en/docs/experience-platform/sources/home) (for example, Meta Ads or Google Ads). They let you report on paid media entities and spend alongside your web and mobile content.
+
+The AI-generated **Asset attributes** and **Experience attributes** described above are also available for paid media creatives — the same featurization runs across the Web, Mobile, and Paid Media channels.
+
+| Title | Description | Type |
+|---|---|---|
+| Ad Network | The advertising network the paid media data was ingested from (for example, `Meta` or `Google Ads`). | Dimension |
+| Account Name | Name of the ad account. | Dimension |
+| Campaign Name | Name of the paid media campaign. | Dimension |
+| Ad Group Name | Name of the ad group (Meta ad set / Google ad group). | Dimension |
+| Ad Name | Name of the individual ad. | Dimension |
+| Experience Name | Name of the ad experience (creative composition) associated with the paid media entity. | Dimension |
+| Asset Name | Name of the creative asset associated with the paid media entity. | Dimension |
+| Impressions | Number of times the paid media ad was shown. | Metric |
+| Clicks | Number of clicks on the paid media ad. | Metric |
+| Spend | Amount spent on the paid media ad, in the ad account currency. | Metric |
+
+{style="table-layout:fixed"}
+
+
 ## Calculated metrics
 
 | Title | Description | Type |
@@ -168,4 +196,3 @@ In the tables below, ![AI generated](/help/assets/icons/AI.svg) indicates an AI/
 | Experience Click-Through Rate | Experience Clicks / Experience Views | Calculated metric |
 
 {style="table-layout:fixed"}
-


### PR DESCRIPTION
## Summary

Documents the **Paid Media** channel components in the Content Analytics components reference. When a customer enables the Paid Media channel in a data view via an Adobe Experience Platform Paid Media source connector (for example, Meta Ads or Google Ads), a set of paid-media-specific components appears in the data view. This page did not previously mention them.

## Changes to `help/content-analytics/report/components.md`

- **`Channel` dimension:** value list now includes `Paid Media` (previously `Web` or `Mobile`).
- **New `## Paid Media` section:** identity dimensions (Ad Network; Account, Campaign, Ad Group, Ad, Experience, and Asset Name) and core metrics (Impressions, Clicks, Spend), plus a note that the AI-generated Asset and Experience attribute featurization also applies to paid media creatives.
- **Category list:** added **Paid Media** entry.

Descriptions are written in customer language, consistent with the surrounding Web/Mobile component documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)